### PR TITLE
Adapted to the new log format

### DIFF
--- a/acceptance_tests/acceptance/fake_print_logs.py
+++ b/acceptance_tests/acceptance/fake_print_logs.py
@@ -20,15 +20,21 @@ def _log_message(es_url, ref, level, message, **kwargs):
     global OFFSET
     OFFSET += 1
     data = {
-        'job_id': ref,
+        'json': {
+            'job_id': ref,
+            'level_name': level,
+            'level_value': LEVEL_VALUE[level],
+            'msg': message,
+        },
         '@timestamp': datetime.datetime.now().isoformat(),
-        'level_name': level,
-        'level_value': LEVEL_VALUE[level],
-        'kubernetes.labels.release': 'prod',
-        'msg': message,
+        'kubernetes': {
+            'labels': {
+                'release': 'prod'
+            }
+        },
         'offset': OFFSET
     }
-    data.update(kwargs)
+    data['json'].update(kwargs)
     headers = {
         "Content-Type": "application/json;charset=UTF-8",
         "Accept": "application/json"

--- a/api/mapfish_print_logs/elastic_search.py
+++ b/api/mapfish_print_logs/elastic_search.py
@@ -24,11 +24,11 @@ def get_logs(ref, min_level, pos, limit, filter_loggers):
                 "must": [
                     {
                         "match_phrase": {
-                            "job_id": ref
+                            "json.job_id": ref
                         }
                     }, {
                         "range": {
-                            "level_value": {
+                            "json.level_value": {
                                 "gte": min_level
                             }
                         }
@@ -52,7 +52,7 @@ def get_logs(ref, min_level, pos, limit, filter_loggers):
         query['query']['bool']['must_not'] = [
             {
                 "match_phrase": {
-                    "logger_name": x
+                    "json.logger_name": x
                 }
             } for x in filter_loggers
         ]

--- a/api/mapfish_print_logs/templates/ref.html.mako
+++ b/api/mapfish_print_logs/templates/ref.html.mako
@@ -87,31 +87,31 @@
         </thead>
         <tbody>
           %for i, log in enumerate(logs):
-          <tr class="level-${log['level_name'] | h}">
+          <tr class="level-${log['json']['level_name'] | h}">
             <td><a data-toggle="collapse" href="#collapse-${i}"></a></td>
             <td>${log['@timestamp'] | h}</td>
-            <td>${log['level_name'] | h}</td>
-            <td class="text-truncate">${log['msg'] | h}</td>
+            <td>${log['json']['level_name'] | h}</td>
+            <td class="text-truncate">${log['json']['msg'] | h}</td>
           </tr>
           <tr class="collapse" id="collapse-${i}">
             <td colspan="4">
               <dl class="border rounded row mx-1 bg-light">
                 <dt class="col-lg-2">Message</dt>
-                <dd class="col-lg-10">${log['msg'] | h}</dd>
-                % if 'logger_name' in log:
+                <dd class="col-lg-10">${log['json']['msg'] | h}</dd>
+                % if 'logger_name' in log['json']:
                 <dt class="col-lg-2">
                   logger
-                  <a title="hide this logger" href="ref?ref=${ref}&min_level=${min_level}&pos=${cur_pos}&filter_loggers=${','.join(filter_loggers + [log['logger_name']])}">✂</a>
+                  <a title="hide this logger" href="ref?ref=${ref}&min_level=${min_level}&pos=${cur_pos}&filter_loggers=${','.join(filter_loggers + [log['json']['logger_name']])}">✂</a>
                 </dt>
-                <dd class="col-lg-10">${log['logger_name'] | h}</dd>
+                <dd class="col-lg-10">${log['json']['logger_name'] | h}</dd>
                 % endif
-                % if 'thread_name' in log:
+                % if 'thread_name' in log['json']:
                   <dt class="col-lg-2">thread</dt>
-                  <dd class="col-lg-10">${log['thread_name'] | h}</dd>
+                  <dd class="col-lg-10">${log['json']['thread_name'] | h}</dd>
                 % endif
-                % if 'stack_trace' in log:
+                % if 'stack_trace' in log['json']:
                 <dt class="col-lg-2">stacktrace</dt>
-                <dd class="col-lg-10"><pre>${log['stack_trace'] | h}</pre></dd>
+                <dd class="col-lg-10"><pre>${log['json']['stack_trace'] | h}</pre></dd>
                 % endif
               </dl>
             </td>


### PR DESCRIPTION
Now, the fields comming from JSON logs are put inside the `json` field as an
object instead of being put at the root.